### PR TITLE
fix: Add fix for incorrect TVL

### DIFF
--- a/src/components/BarChart/alt.tsx
+++ b/src/components/BarChart/alt.tsx
@@ -7,6 +7,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import useTheme from 'hooks/useTheme'
 import { VolumeWindow } from 'types'
+import { LoadingRows } from 'components/Loader'
 dayjs.extend(utc)
 
 const DEFAULT_HEIGHT = 300
@@ -86,63 +87,75 @@ const Chart = ({
         {topLeft ?? null}
         {topRight ?? null}
       </RowBetween>
-      <ResponsiveContainer width="100%" height="100%">
-        <BarChart
-          width={500}
-          height={300}
-          data={data}
-          margin={{
-            top: 5,
-            right: 30,
-            left: 20,
-            bottom: 5,
-          }}
-          onMouseLeave={() => {
-            setLabel && setLabel(undefined)
-            setValue && setValue(undefined)
-          }}
-        >
-          <XAxis
-            dataKey="time"
-            axisLine={false}
-            tickLine={false}
-            tickFormatter={(time) => dayjs(time).format(activeWindow === VolumeWindow.monthly ? 'MMM' : 'DD')}
-            minTickGap={10}
-          />
-          <Tooltip
-            cursor={{ fill: theme.bg2 }}
-            contentStyle={{ display: 'none' }}
-            formatter={(value: number, name: string, props: { payload: { time: string; value: number } }) => {
-              if (setValue && parsedValue !== props.payload.value) {
-                setValue(props.payload.value)
-              }
-              const formattedTime = dayjs(props.payload.time).format('MMM D')
-              const formattedTimeDaily = dayjs(props.payload.time).format('MMM D YYYY')
-              const formattedTimePlusWeek = dayjs(props.payload.time).add(1, 'week')
-              const formattedTimePlusMonth = dayjs(props.payload.time).add(1, 'month')
-
-              if (setLabel && label !== formattedTime) {
-                if (activeWindow === VolumeWindow.weekly) {
-                  const isCurrent = formattedTimePlusWeek.isAfter(now)
-                  setLabel(formattedTime + '-' + (isCurrent ? 'current' : formattedTimePlusWeek.format('MMM D, YYYY')))
-                } else if (activeWindow === VolumeWindow.monthly) {
-                  const isCurrent = formattedTimePlusMonth.isAfter(now)
-                  setLabel(formattedTime + '-' + (isCurrent ? 'current' : formattedTimePlusMonth.format('MMM D, YYYY')))
-                } else {
-                  setLabel(formattedTimeDaily)
+      {data?.length === 0 ? (
+        <LoadingRows>
+          <div />
+          <div />
+          <div />
+        </LoadingRows>
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            width={500}
+            height={300}
+            data={data}
+            margin={{
+              top: 5,
+              right: 30,
+              left: 20,
+              bottom: 5,
+            }}
+            onMouseLeave={() => {
+              setLabel && setLabel(undefined)
+              setValue && setValue(undefined)
+            }}
+          >
+            <XAxis
+              dataKey="time"
+              axisLine={false}
+              tickLine={false}
+              tickFormatter={(time) => dayjs(time).format(activeWindow === VolumeWindow.monthly ? 'MMM' : 'DD')}
+              minTickGap={10}
+            />
+            <Tooltip
+              cursor={{ fill: theme.bg2 }}
+              contentStyle={{ display: 'none' }}
+              formatter={(value: number, name: string, props: { payload: { time: string; value: number } }) => {
+                if (setValue && parsedValue !== props.payload.value) {
+                  setValue(props.payload.value)
                 }
-              }
-            }}
-          />
-          <Bar
-            dataKey="value"
-            fill={color}
-            shape={(props) => {
-              return <CustomBar height={props.height} width={props.width} x={props.x} y={props.y} fill={color} />
-            }}
-          />
-        </BarChart>
-      </ResponsiveContainer>
+                const formattedTime = dayjs(props.payload.time).format('MMM D')
+                const formattedTimeDaily = dayjs(props.payload.time).format('MMM D YYYY')
+                const formattedTimePlusWeek = dayjs(props.payload.time).add(1, 'week')
+                const formattedTimePlusMonth = dayjs(props.payload.time).add(1, 'month')
+
+                if (setLabel && label !== formattedTime) {
+                  if (activeWindow === VolumeWindow.weekly) {
+                    const isCurrent = formattedTimePlusWeek.isAfter(now)
+                    setLabel(
+                      formattedTime + '-' + (isCurrent ? 'current' : formattedTimePlusWeek.format('MMM D, YYYY'))
+                    )
+                  } else if (activeWindow === VolumeWindow.monthly) {
+                    const isCurrent = formattedTimePlusMonth.isAfter(now)
+                    setLabel(
+                      formattedTime + '-' + (isCurrent ? 'current' : formattedTimePlusMonth.format('MMM D, YYYY'))
+                    )
+                  } else {
+                    setLabel(formattedTimeDaily)
+                  }
+                }
+              }}
+            />
+            <Bar
+              dataKey="value"
+              fill={color}
+              shape={(props) => {
+                return <CustomBar height={props.height} width={props.width} x={props.x} y={props.y} fill={color} />
+              }}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
       <RowBetween>
         {bottomLeft ?? null}
         {bottomRight ?? null}

--- a/src/components/LineChart/alt.tsx
+++ b/src/components/LineChart/alt.tsx
@@ -7,6 +7,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import useTheme from 'hooks/useTheme'
 import { darken } from 'polished'
+import { LoadingRows } from 'components/Loader'
 dayjs.extend(utc)
 
 const DEFAULT_HEIGHT = 300
@@ -17,7 +18,7 @@ const Wrapper = styled(Card)`
   padding: 1rem;
   padding-right: 2rem;
   display: flex;
-  background-color: ${({ theme }) => theme.bg0}
+  background-color: ${({ theme }) => theme.bg0};
   flex-direction: column;
   > * {
     font-size: 1rem;
@@ -62,49 +63,57 @@ const Chart = ({
         {topLeft ?? null}
         {topRight ?? null}
       </RowBetween>
-      <ResponsiveContainer width="100%" height="100%">
-        <AreaChart
-          width={500}
-          height={300}
-          data={data}
-          margin={{
-            top: 5,
-            right: 30,
-            left: 20,
-            bottom: 5,
-          }}
-          onMouseLeave={() => {
-            setLabel && setLabel(undefined)
-            setValue && setValue(undefined)
-          }}
-        >
-          <defs>
-            <linearGradient id="gradient" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor={darken(0.36, color)} stopOpacity={0.5} />
-              <stop offset="100%" stopColor={color} stopOpacity={0} />
-            </linearGradient>
-          </defs>
-          <XAxis
-            dataKey="time"
-            axisLine={false}
-            tickLine={false}
-            tickFormatter={(time) => dayjs(time).format('DD')}
-            minTickGap={10}
-          />
-          <Tooltip
-            cursor={{ stroke: theme.bg2 }}
-            contentStyle={{ display: 'none' }}
-            formatter={(value: number, name: string, props: { payload: { time: string; value: number } }) => {
-              if (setValue && parsedValue !== props.payload.value) {
-                setValue(props.payload.value)
-              }
-              const formattedTime = dayjs(props.payload.time).format('MMM D, YYYY')
-              if (setLabel && label !== formattedTime) setLabel(formattedTime)
+      {data?.length === 0 ? (
+        <LoadingRows>
+          <div />
+          <div />
+          <div />
+        </LoadingRows>
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart
+            width={500}
+            height={300}
+            data={data}
+            margin={{
+              top: 5,
+              right: 30,
+              left: 20,
+              bottom: 5,
             }}
-          />
-          <Area dataKey="value" type="monotone" stroke={color} fill="url(#gradient)" strokeWidth={2} />
-        </AreaChart>
-      </ResponsiveContainer>
+            onMouseLeave={() => {
+              setLabel && setLabel(undefined)
+              setValue && setValue(undefined)
+            }}
+          >
+            <defs>
+              <linearGradient id="gradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={darken(0.36, color)} stopOpacity={0.5} />
+                <stop offset="100%" stopColor={color} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <XAxis
+              dataKey="time"
+              axisLine={false}
+              tickLine={false}
+              tickFormatter={(time) => dayjs(time).format('DD')}
+              minTickGap={10}
+            />
+            <Tooltip
+              cursor={{ stroke: theme.bg2 }}
+              contentStyle={{ display: 'none' }}
+              formatter={(value: number, name: string, props: { payload: { time: string; value: number } }) => {
+                if (setValue && parsedValue !== props.payload.value) {
+                  setValue(props.payload.value)
+                }
+                const formattedTime = dayjs(props.payload.time).format('MMM D, YYYY')
+                if (setLabel && label !== formattedTime) setLabel(formattedTime)
+              }}
+            />
+            <Area dataKey="value" type="monotone" stroke={color} fill="url(#gradient)" strokeWidth={2} />
+          </AreaChart>
+        </ResponsiveContainer>
+      )}
       <RowBetween>
         {bottomLeft ?? null}
         {bottomRight ?? null}

--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -101,7 +101,7 @@ export const LoadingRows = styled.div`
   max-width: 100%;
   grid-column-gap: 0.5em;
   grid-row-gap: 0.8em;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(1, 1fr);
   & > div {
     animation: ${loadingAnimation} 1.5s infinite;
     animation-fill-mode: both;

--- a/src/data/pools/topPools.ts
+++ b/src/data/pools/topPools.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react'
 import { useQuery } from '@apollo/client'
 import gql from 'graphql-tag'
 import { useClients } from 'state/application/hooks'
+import { notEmpty } from 'utils'
+import { POOL_HIDE } from '../../constants'
 
 export const TOP_POOLS = gql`
   query topPools {
@@ -33,7 +35,14 @@ export function useTopPoolAddresses(): {
 
   const formattedData = useMemo(() => {
     if (data) {
-      return data.pools.map((p) => p.id)
+      return data.pools
+        .map((p) => {
+          if (POOL_HIDE.includes(p.id.toLocaleLowerCase())) {
+            return undefined
+          }
+          return p.id
+        })
+        .filter(notEmpty)
     } else {
       return undefined
     }

--- a/src/data/protocol/derived.ts
+++ b/src/data/protocol/derived.ts
@@ -1,0 +1,131 @@
+import { SupportedNetwork } from 'constants/networks'
+import { fetchPoolChartData } from 'data/pools/chartData'
+import { usePoolDatas } from 'data/pools/poolData'
+import { useTopPoolAddresses } from 'data/pools/topPools'
+import { useEffect, useMemo, useState } from 'react'
+import { useDispatch } from 'react-redux'
+import { AppDispatch } from 'state'
+import { useDataClient } from 'state/application/hooks'
+import { updatePoolChartData } from 'state/pools/actions'
+import { PoolChartEntry, PoolData } from 'state/pools/reducer'
+import { ChartDayData } from 'types'
+import { POOL_HIDE } from '../../constants'
+
+/**
+ * Calculates offset amount to avoid inaccurate USD data for global TVL.
+ * @returns TVL value in USD
+ */
+export function useTVLOffset() {
+  const { data } = usePoolDatas(POOL_HIDE)
+  const tvlOffset = useMemo(() => {
+    if (!data) return 0
+    return Object.keys(data).reduce((accum: number, poolAddress) => {
+      const poolData: PoolData = data[poolAddress]
+      return accum + poolData.tvlUSD
+    }, 0)
+  }, [data])
+  return tvlOffset
+}
+
+/**
+ * Fecthes and formats data for pools that result in incorrect USD TVL.
+ *
+ * Note: not used currently but useful for debugging.
+ *
+ * @returns Chart data by day for values to offset accurate USD.
+ */
+export function useDerivedOffsetTVLHistory() {
+  const dataClient = useDataClient()
+  const [chartData, setChartData] = useState<{ [key: number]: ChartDayData } | undefined>(undefined)
+  const dispatch = useDispatch<AppDispatch>()
+
+  useEffect(() => {
+    async function fetchAll() {
+      // fetch all data for each pool
+      const data = await POOL_HIDE.reduce(async (accumP: Promise<{ [key: number]: ChartDayData }>, address) => {
+        const accum = await accumP
+        const { data } = await fetchPoolChartData(address, dataClient)
+        if (!data) return accum
+        dispatch(updatePoolChartData({ poolAddress: address, chartData: data, networkId: SupportedNetwork.ETHEREUM }))
+        data.map((poolDayData: PoolChartEntry) => {
+          const { date, totalValueLockedUSD, volumeUSD } = poolDayData
+          const roundedDate = date
+          if (!accum[roundedDate]) {
+            accum[roundedDate] = {
+              tvlUSD: 0,
+              date: roundedDate,
+              volumeUSD: 0,
+            }
+          }
+          accum[roundedDate].tvlUSD = accum[roundedDate].tvlUSD + totalValueLockedUSD
+          accum[roundedDate].volumeUSD = accum[roundedDate].volumeUSD + volumeUSD
+        })
+        return accum
+      }, Promise.resolve({} as { [key: number]: ChartDayData }))
+
+      // Format as array
+      setChartData(data)
+    }
+
+    if (!chartData) {
+      fetchAll()
+    }
+  }, [chartData, dataClient, dispatch])
+
+  return chartData
+}
+
+// # of pools to include in historical chart volume and TVL data
+const PoolCountAggregate = 20
+
+/**
+ * Derives historical TVL data for top 50 pools.
+ * @returns Chart data for aggregate Uniswap TVL over time.
+ */
+export function useDerivedProtocolTVLHistory() {
+  const dataClient = useDataClient()
+  const { addresses } = useTopPoolAddresses()
+  const dispatch = useDispatch<AppDispatch>()
+
+  const [chartData, setChartData] = useState<ChartDayData[] | undefined>(undefined)
+
+  useEffect(() => {
+    async function fetchAll() {
+      if (!addresses) {
+        return
+      }
+      // fetch all data for each pool
+      const data = await addresses
+        .slice(0, PoolCountAggregate) // @TODO: must be replaced with aggregate with subgraph data fixed.
+        .reduce(async (accumP: Promise<{ [key: number]: ChartDayData }>, address) => {
+          const accum = await accumP
+          const { data } = await fetchPoolChartData(address, dataClient)
+          if (!data) return accum
+          dispatch(updatePoolChartData({ poolAddress: address, chartData: data, networkId: SupportedNetwork.ETHEREUM }))
+          data.map((poolDayData: PoolChartEntry) => {
+            const { date, totalValueLockedUSD, volumeUSD } = poolDayData
+            const roundedDate = date
+            if (!accum[roundedDate]) {
+              accum[roundedDate] = {
+                tvlUSD: 0,
+                date: roundedDate,
+                volumeUSD: 0,
+              }
+            }
+            accum[roundedDate].tvlUSD = accum[roundedDate].tvlUSD + totalValueLockedUSD
+            accum[roundedDate].volumeUSD = accum[roundedDate].volumeUSD + volumeUSD
+          })
+          return accum
+        }, Promise.resolve({} as { [key: number]: ChartDayData }))
+
+      // Format as array
+      setChartData(Object.values(data))
+    }
+
+    if (!chartData) {
+      fetchAll()
+    }
+  }, [addresses, chartData, dataClient])
+
+  return chartData
+}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -5,7 +5,7 @@ import { TYPE } from 'theme'
 import { ResponsiveRow, RowBetween, RowFixed } from 'components/Row'
 import LineChart from 'components/LineChart/alt'
 import useTheme from 'hooks/useTheme'
-import { useProtocolData, useProtocolChartData, useProtocolTransactions } from 'state/protocol/hooks'
+import { useProtocolChartData, useProtocolData, useProtocolTransactions } from 'state/protocol/hooks'
 import { DarkGreyCard } from 'components/Card'
 import { formatDollarAmount } from 'utils/numbers'
 import Percent from 'components/Percent'
@@ -43,13 +43,15 @@ export default function Home() {
   const [activeNetwork] = useActiveNetworkVersion()
 
   const [protocolData] = useProtocolData()
-  const [chartData] = useProtocolChartData()
   const [transactions] = useProtocolTransactions()
 
   const [volumeHover, setVolumeHover] = useState<number | undefined>()
   const [liquidityHover, setLiquidityHover] = useState<number | undefined>()
   const [leftLabel, setLeftLabel] = useState<string | undefined>()
   const [rightLabel, setRightLabel] = useState<string | undefined>()
+
+  // Hot fix to remove errors in TVL data while subgraph syncs.
+  const [chartData] = useProtocolChartData()
 
   useEffect(() => {
     setLiquidityHover(undefined)
@@ -113,7 +115,14 @@ export default function Home() {
       .filter(notEmpty)
   }, [allTokens])
 
-  const [volumeWindow, setVolumeWindow] = useState(VolumeWindow.daily)
+  const [volumeWindow, setVolumeWindow] = useState(VolumeWindow.weekly)
+
+  const tvlValue = useMemo(() => {
+    if (liquidityHover) {
+      return formatDollarAmount(liquidityHover, 2, true)
+    }
+    return formatDollarAmount(protocolData?.tvlUSD, 2, true)
+  }, [liquidityHover, protocolData?.tvlUSD])
 
   return (
     <PageWrapper>
@@ -135,7 +144,7 @@ export default function Home() {
                 <AutoColumn gap="4px">
                   <TYPE.mediumHeader fontSize="16px">TVL</TYPE.mediumHeader>
                   <TYPE.largeHeader fontSize="32px">
-                    <MonoSpace>{formatDollarAmount(liquidityHover, 2, true)} </MonoSpace>
+                    <MonoSpace>{tvlValue} </MonoSpace>
                   </TYPE.largeHeader>
                   <TYPE.main fontSize="12px" height="14px">
                     {leftLabel ? <MonoSpace>{leftLabel} (UTC)</MonoSpace> : null}

--- a/src/pages/Pool/PoolPage.tsx
+++ b/src/pages/Pool/PoolPage.tsx
@@ -17,7 +17,6 @@ import Percent from 'components/Percent'
 import { ButtonPrimary, ButtonGray, SavedIcon } from 'components/Button'
 import { DarkGreyCard, GreyCard, GreyBadge } from 'components/Card'
 import { usePoolDatas, usePoolChartData, usePoolTransactions } from 'state/pools/hooks'
-import LineChart from 'components/LineChart/alt'
 import { unixToDate } from 'utils/date'
 import { ToggleWrapper, ToggleElementFree } from 'components/Toggle/index'
 import BarChart from 'components/BarChart/alt'
@@ -67,7 +66,6 @@ const ToggleRow = styled(RowBetween)`
 `
 
 enum ChartView {
-  TVL,
   VOL,
   PRICE,
   DENSITY,
@@ -294,16 +292,9 @@ export default function PoolPage({
                   <ToggleElementFree
                     isActive={view === ChartView.VOL}
                     fontSize="12px"
-                    onClick={() => (view === ChartView.VOL ? setView(ChartView.TVL) : setView(ChartView.VOL))}
+                    onClick={() => (view === ChartView.VOL ? setView(ChartView.DENSITY) : setView(ChartView.VOL))}
                   >
                     Volume
-                  </ToggleElementFree>
-                  <ToggleElementFree
-                    isActive={view === ChartView.TVL}
-                    fontSize="12px"
-                    onClick={() => (view === ChartView.TVL ? setView(ChartView.DENSITY) : setView(ChartView.TVL))}
-                  >
-                    TVL
                   </ToggleElementFree>
                   {activeNetwork === ArbitrumNetworkInfo ? null : (
                     <ToggleElementFree
@@ -317,23 +308,13 @@ export default function PoolPage({
                   <ToggleElementFree
                     isActive={view === ChartView.FEES}
                     fontSize="12px"
-                    onClick={() => (view === ChartView.FEES ? setView(ChartView.TVL) : setView(ChartView.FEES))}
+                    onClick={() => (view === ChartView.FEES ? setView(ChartView.VOL) : setView(ChartView.FEES))}
                   >
                     Fees
                   </ToggleElementFree>
                 </ToggleWrapper>
               </ToggleRow>
-              {view === ChartView.TVL ? (
-                <LineChart
-                  data={formattedTvlData}
-                  setLabel={setValueLabel}
-                  color={backgroundColor}
-                  minHeight={340}
-                  setValue={setLatestValue}
-                  value={latestValue}
-                  label={valueLabel}
-                />
-              ) : view === ChartView.VOL ? (
+              {view === ChartView.VOL ? (
                 <BarChart
                   data={formattedVolumeData}
                   color={backgroundColor}

--- a/src/state/pools/updater.ts
+++ b/src/state/pools/updater.ts
@@ -2,6 +2,7 @@ import { useUpdatePoolData, useAllPoolData, useAddPoolKeys } from './hooks'
 import { useEffect, useMemo } from 'react'
 import { useTopPoolAddresses } from 'data/pools/topPools'
 import { usePoolDatas } from 'data/pools/poolData'
+import { POOL_HIDE } from '../../constants'
 
 export default function Updater(): null {
   // updaters
@@ -18,6 +19,11 @@ export default function Updater(): null {
       addPoolKeys(addresses)
     }
   }, [addPoolKeys, addresses, error, loading])
+
+  // load data for pools we need to hide
+  useEffect(() => {
+    addPoolKeys(POOL_HIDE)
+  }, [addPoolKeys])
 
   // detect for which addresses we havent loaded pool data yet
   const unfetchedPoolAddresses = useMemo(() => {


### PR DESCRIPTION
This is a client side fix for the inaccurate TVL values displayed on the global and also pool specific charts. 

Can see related issue here on subgraph repo https://github.com/Uniswap/v3-subgraph/issues/74

Uses a safer, more strict, yet slower method for calculating historical and current USD TVL. Also removes fees from calculated TVL in pool specific pages. 

Follow up: fix issue on the underlying subgraph  