### PR TITLE
Fix: Show fees amount instead of TVL on Pool Page's fee chart

### DIFF
--- a/src/pages/Pool/PoolPage.tsx
+++ b/src/pages/Pool/PoolPage.tsx
@@ -279,6 +279,8 @@ export default function PoolPage({
                         ? formatDollarAmount(latestValue)
                         : view === ChartView.VOL
                         ? formatDollarAmount(formattedVolumeData[formattedVolumeData.length - 1]?.value)
+                        : view === ChartView.FEES
+                        ? formatDollarAmount(formattedFeesUSD[formattedFeesUSD.length - 1]?.value)
                         : view === ChartView.DENSITY
                         ? ''
                         : formatDollarAmount(formattedTvlData[formattedTvlData.length - 1]?.value)}{' '}


### PR DESCRIPTION
Currently TVL value is displayed on fees chart by default which is confusing for the users
I've changed it to load the current day's fees instead.

![Screenshot 2022-12-15 at 17 21 38](https://user-images.githubusercontent.com/62555364/207898895-e71a40ce-728d-4b07-b26a-d36b1522add2.png)
