### PR TITLE
fix: Revert "fix: change arbitrum subgraph"

### DIFF
--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -49,7 +49,7 @@ export const client = new ApolloClient({
 })
 
 export const arbitrumClient = new ApolloClient({
-  uri: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-minimal',
+  uri: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-arbitrum-one',
   cache: new InMemoryCache({
     typePolicies: {
       Token: {

--- a/src/data/application/index.ts
+++ b/src/data/application/index.ts
@@ -53,7 +53,7 @@ export function useFetchedSubgraphStatus(): {
         activeNetwork === EthereumNetworkInfo
           ? 'uniswap/uniswap-v3'
           : activeNetwork === ArbitrumNetworkInfo
-          ? 'ianlapham/arbitrum-minimal'
+          ? 'ianlapham/uniswap-arbitrum-one'
           : 'ianlapham/uniswap-optimism',
     },
   })


### PR DESCRIPTION
This has the latest subgraph information, minimal was synced over 2 years ago.

Reverts Uniswap/v3-info#281