### PR TITLE
fix: rename avax to avalanche in the dropdown

### DIFF
--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -101,7 +101,7 @@ export const AvalancheNetworkInfo: NetworkInfo = {
   chainId: 43114,
   id: SupportedNetwork.AVALANCHE,
   route: 'avax',
-  name: 'Avax',
+  name: 'Avalanche',
   bgColor: '#e84142',
   primaryColor: '#e84142',
   secondaryColor: '#e84142',


### PR DESCRIPTION
https://uniswapteam.slack.com/archives/C02PVER4H7C/p1689182313529659
![Screenshot 2023-07-12 at 10 41 07 AM](https://github.com/Uniswap/v3-info/assets/11512321/dc243fd3-1203-4a32-86c5-e7e26d03e04c)
