### PR TITLE
Fix: Blank page when navigating from the tokens page

### DIFF
--- a/src/components/tokens/TokenTable.tsx
+++ b/src/components/tokens/TokenTable.tsx
@@ -16,6 +16,7 @@ import HoverInlineText from '../HoverInlineText'
 import useTheme from 'hooks/useTheme'
 import { TOKEN_HIDE } from '../../constants/index'
 import { useActiveNetworkVersion } from 'state/application/hooks'
+import { networkPrefix } from 'utils/networkPrefix'
 
 const Wrapper = styled(DarkGreyCard)`
   width: 100%;
@@ -69,9 +70,10 @@ const ResponsiveLogo = styled(CurrencyLogo)`
 `
 
 const DataRow = ({ tokenData, index }: { tokenData: TokenData; index: number }) => {
+  const [activeNetwork] = useActiveNetworkVersion()
   const theme = useTheme()
   return (
-    <LinkWrapper to={'tokens/' + tokenData.address}>
+    <LinkWrapper to={networkPrefix(activeNetwork) + 'tokens/' + tokenData.address}>
       <ResponsiveGrid>
         <Label>{index + 1}</Label>
         <Label>


### PR DESCRIPTION
### Issue
When the user navigates to a specific token (Eg. Ether) from the tokens page, the url shows 'tokens' twice. While on the default network (Ethereum) it still displays the token page for the token, on a different network (Eg. Optimism), a blank page is shown to the user.

The below screenshot is when navigating to a specific token on the Ethereum network from tokens page (The url shows 'tokens' twice but still displays the token details)

![Ethereum network token page screenshot](https://github.com/Uniswap/v3-info/assets/37153833/82dc6360-12bb-4c6a-b0c6-5da96dc3e070)

The below screenshot is when navigating from tokens page on other networks (The page breaks and a blank page is shown)

![Optimism network token page screenshot](https://github.com/Uniswap/v3-info/assets/37153833/c9c6c237-2d02-432d-af3a-b116c95a39ce)

### Steps to reproduce

1. Change the network from Ethereum to any other network (Eg. Optimism)
2. Go to the tokens page
3. Click on a token to view the token details (Eg. Wrapped Ether)
4. A blank page is shown to the user.