### PR TITLE
fix: Update Arbitrum Subgraph to working version

### DIFF
--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -92,7 +92,7 @@ export const avalancheBlockClient = new ApolloClient({
 })
 
 export const arbitrumClient = new ApolloClient({
-  uri: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-arbitrum-one?source=uniswap',
+  uri: 'https://api.thegraph.com/subgraphs/name/graph-buildersdao/univ3-arbitrum-minimal?source=uniswap',
   cache: new InMemoryCache({
     typePolicies: {
       Token: {


### PR DESCRIPTION
The Arbitrum subgraph that got repaired was the minimal version. The old version, has indexing errors and not pulling up data.

This was tested locally. The data looks to be correct. Without much of an data audit

<img width="1622" alt="Uniswap_Info_and_GitHub_Desktop" src="https://github.com/Uniswap/v3-info/assets/60412342/bd026aed-3eb4-4c8c-8c5e-aee641f64804">
