### PR TITLE
Fix: Blockchain explorer links only ETH

### DIFF
--- a/src/components/Header/Polling.tsx
+++ b/src/components/Header/Polling.tsx
@@ -6,7 +6,6 @@ import { useActiveNetworkVersion, useSubgraphStatus } from '../../state/applicat
 import { ExplorerDataType, getExplorerLink } from '../../utils'
 import useTheme from 'hooks/useTheme'
 import { EthereumNetworkInfo } from 'constants/networks'
-import { ChainId } from '@uniswap/sdk-core'
 
 const StyledPolling = styled.div`
   display: flex;
@@ -87,7 +86,7 @@ export default function Polling() {
 
   return (
     <ExternalLink
-      href={latestBlock ? getExplorerLink(ChainId.MAINNET, latestBlock.toString(), ExplorerDataType.BLOCK) : ''}
+      href={latestBlock ? getExplorerLink(activeNetwork.chainId, latestBlock.toString(), ExplorerDataType.BLOCK) : ''}
     >
       <StyledPolling>
         <TYPE.small mr="4px" color={theme?.text3}>

--- a/src/components/TransactionsTable/index.tsx
+++ b/src/components/TransactionsTable/index.tsx
@@ -98,7 +98,7 @@ const DataRow = ({ transaction, color }: { transaction: Transaction; color?: str
 
   return (
     <ResponsiveGrid>
-      <ExternalLink href={getExplorerLink(ChainId.MAINNET, transaction.hash, ExplorerDataType.TRANSACTION)}>
+      <ExternalLink href={getExplorerLink(activeNetwork.chainId, transaction.hash, ExplorerDataType.TRANSACTION)}>
         <Label color={color ?? theme?.blue1} fontWeight={400}>
           {transaction.type === TransactionType.MINT
             ? `Add ${transaction.token0Symbol} and ${transaction.token1Symbol}`

--- a/src/pages/Pool/PoolPage.tsx
+++ b/src/pages/Pool/PoolPage.tsx
@@ -31,7 +31,6 @@ import { GenericImageWrapper } from 'components/Logo'
 import { Navigate, useParams } from 'react-router-dom'
 import { Trace } from '@uniswap/analytics'
 import { InterfacePageName } from '@uniswap/analytics-events'
-import { ChainId } from '@uniswap/sdk-core'
 
 const ContentLayout = styled.div`
   display: grid;
@@ -166,7 +165,7 @@ function PoolPage({ address }: { address: string }) {
               </AutoRow>
               <RowFixed gap="10px" align="center">
                 <SavedIcon fill={savedPools.includes(address)} onClick={() => addSavedPool(address)} />
-                <StyledExternalLink href={getExplorerLink(ChainId.MAINNET, address, ExplorerDataType.ADDRESS)}>
+                <StyledExternalLink href={getExplorerLink(activeNetwork.chainId, address, ExplorerDataType.ADDRESS)}>
                   <ExternalLink stroke={theme?.text2} size={'17px'} style={{ marginLeft: '12px' }} />
                 </StyledExternalLink>
               </RowFixed>

--- a/src/pages/Token/TokenPage.tsx
+++ b/src/pages/Token/TokenPage.tsx
@@ -42,7 +42,6 @@ import { useCMCLink } from 'hooks/useCMCLink'
 import CMCLogo from '../../assets/images/cmc.png'
 import { useParams } from 'react-router-dom'
 import { Trace } from '@uniswap/analytics'
-import { ChainId } from '@uniswap/sdk-core'
 
 const PriceText = styled(TYPE.label)`
   font-size: 36px;
@@ -191,7 +190,7 @@ export default function TokenPage() {
                     <TYPE.main>{` > `}</TYPE.main>
                     <TYPE.label>{` ${tokenData.symbol} `}</TYPE.label>
                     <StyledExternalLink
-                      href={getExplorerLink(ChainId.MAINNET, formattedAddress, ExplorerDataType.ADDRESS)}
+                      href={getExplorerLink(activeNetwork.chainId, formattedAddress, ExplorerDataType.ADDRESS)}
                     >
                       <TYPE.main>{` (${shortenAddress(formattedAddress)}) `}</TYPE.main>
                     </StyledExternalLink>
@@ -207,7 +206,7 @@ export default function TokenPage() {
                       </StyledExternalLink>
                     )}
                     <StyledExternalLink
-                      href={getExplorerLink(ChainId.MAINNET, formattedAddress, ExplorerDataType.ADDRESS)}
+                      href={getExplorerLink(activeNetwork.chainId, formattedAddress, ExplorerDataType.ADDRESS)}
                     >
                       <ExternalLink stroke={theme?.text2} size={'17px'} style={{ marginLeft: '12px' }} />
                     </StyledExternalLink>


### PR DESCRIPTION
Currently the block explorer links are chain agnostic.

This will add the network chains to the explorer.


locally tested