### PR TITLE
fix: use active network chain id instead of mainnet in transactions transactions table

### DIFF
--- a/src/components/TransactionsTable/index.tsx
+++ b/src/components/TransactionsTable/index.tsx
@@ -15,7 +15,6 @@ import useTheme from 'hooks/useTheme'
 import HoverInlineText from 'components/HoverInlineText'
 import { useActiveNetworkVersion } from 'state/application/hooks'
 import { OptimismNetworkInfo } from 'constants/networks'
-import { ChainId } from '@uniswap/sdk-core'
 
 const Wrapper = styled(DarkGreyCard)`
   width: 100%;
@@ -98,7 +97,7 @@ const DataRow = ({ transaction, color }: { transaction: Transaction; color?: str
 
   return (
     <ResponsiveGrid>
-      <ExternalLink href={getExplorerLink(ChainId.MAINNET, transaction.hash, ExplorerDataType.TRANSACTION)}>
+      <ExternalLink href={getExplorerLink(activeNetwork.chainId, transaction.hash, ExplorerDataType.TRANSACTION)}>
         <Label color={color ?? theme?.blue1} fontWeight={400}>
           {transaction.type === TransactionType.MINT
             ? `Add ${transaction.token0Symbol} and ${transaction.token1Symbol}`
@@ -118,7 +117,7 @@ const DataRow = ({ transaction, color }: { transaction: Transaction; color?: str
       </Label>
       <Label end={1} fontWeight={400}>
         <ExternalLink
-          href={getExplorerLink(ChainId.MAINNET, transaction.sender, ExplorerDataType.ADDRESS)}
+          href={getExplorerLink(activeNetwork.chainId, transaction.sender, ExplorerDataType.ADDRESS)}
           style={{ color: color ?? theme?.blue1 }}
         >
           {shortenAddress(transaction.sender)}


### PR DESCRIPTION
Links in transactions table was always redirecting on etherscan because getExplorerLink was used everytime with the mainnet chain id so i replaced it by activeNetwork.chainId, now it works with all networks :)